### PR TITLE
chore(deps): update react-simple-code-editor to ^0.13.1

### DIFF
--- a/packages/react-live-runner/package.json
+++ b/packages/react-live-runner/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "prism-react-renderer": "^1.2.1",
     "react-runner": "^1.0.3",
-    "react-simple-code-editor": "^0.11.0"
+    "react-simple-code-editor": "^0.13.1"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17 || ^18",

--- a/packages/react-live-runner/src/CodeEditor.tsx
+++ b/packages/react-live-runner/src/CodeEditor.tsx
@@ -13,17 +13,14 @@ import defaultTheme from './defaultTheme'
 
 type EditorProps = ComponentPropsWithoutRef<typeof Editor>
 
-export type CodeEditorProps = Omit<
-  EditorProps,
-  'defaultValue' | 'value' | 'onValueChange' | 'highlight' | 'onChange'
+export type CodeEditorProps = Partial<
+  Omit<EditorProps, 'defaultValue' | 'value' | 'onValueChange' | 'onChange'>
 > & {
   defaultValue?: string
   value?: string
   language?: Language
-  padding?: string | number
   theme?: Theme
   Prism?: PrismLib
-  highlight?: EditorProps['highlight']
   onChange?: (value: string) => void
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7976,10 +7976,10 @@ react-shallow-renderer@^16.13.1:
     object-assign "^4.1.1"
     react-is "^16.12.0 || ^17.0.0 || ^18.0.0"
 
-react-simple-code-editor@^0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/react-simple-code-editor/-/react-simple-code-editor-0.11.0.tgz#bb57c7c29b570f2ab229872599eac184f5bc673c"
-  integrity sha512-xGfX7wAzspl113ocfKQAR8lWPhavGWHL3xSzNLeseDRHysT+jzRBi/ExdUqevSMos+7ZtdfeuBOXtgk9HTwsrw==
+react-simple-code-editor@^0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/react-simple-code-editor/-/react-simple-code-editor-0.13.1.tgz#4514553fa132dcaffec33a6612c58f1613c52416"
+  integrity sha512-XYeVwRZwgyKtjNIYcAEgg2FaQcCZwhbarnkJIV20U2wkCU9q/CPFBo8nRXrK4GXUz3AvbqZFsZRrpUTkqqEYyQ==
 
 react-test-renderer@^18.0.0:
   version "18.0.0"


### PR DESCRIPTION
[React simple code editor](https://github.com/react-simple-code-editor/react-simple-code-editor) has shipped to TypeScript
and updated its `peerDependencies`.

Close #123.