### PR TITLE
fix: types export

### DIFF
--- a/packages/react-live-runner/package.json
+++ b/packages/react-live-runner/package.json
@@ -21,7 +21,8 @@
   "unpkg": "dist/index.umd.js",
   "exports": {
     "require": "./dist/index.js",
-    "default": "./dist/index.modern.js"
+    "default": "./dist/index.modern.js",
+    "types": "./dist/index.d.ts"
   },
   "types": "dist/index.d.ts",
   "sideEffects": false,

--- a/packages/react-runner-codemirror/package.json
+++ b/packages/react-runner-codemirror/package.json
@@ -21,7 +21,8 @@
   "unpkg": "dist/index.umd.js",
   "exports": {
     "require": "./dist/index.js",
-    "default": "./dist/index.modern.js"
+    "default": "./dist/index.modern.js",
+    "types": "./dist/index.d.ts"
   },
   "types": "dist/index.d.ts",
   "sideEffects": false,

--- a/packages/react-runner/package.json
+++ b/packages/react-runner/package.json
@@ -21,7 +21,8 @@
   "unpkg": "dist/index.umd.js",
   "exports": {
     "require": "./dist/index.js",
-    "default": "./dist/index.modern.js"
+    "default": "./dist/index.modern.js",
+    "types": "./dist/index.d.ts"
   },
   "types": "dist/index.d.ts",
   "sideEffects": false,


### PR DESCRIPTION
When using `react-runner` with a modern TS setup it's complaining that the declaration files for the module can't be found:

```sh
Could not find a declaration file for module 'react-runner'. '/Users/kbrabrand/development/behalf/aidn/aidn.no/node_modules/react-runner/dist/index.modern.js' implicitly has an 'any' type.
  There are types at '/Users/kbrabrand/development/behalf/aidn/aidn.no/node_modules/react-runner/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'react-runner' library may need to update its package.json or typings.ts(7016)  
```

This is caused by the TS compiler not looking at the `types` key of the `package.json` file if an `exports` key is also provided. This PR adds the path to the types to the list of `exports` in order to fix this.

I think this fix also addresses what's raised in #160 